### PR TITLE
集中管理依赖并优化技能配置

### DIFF
--- a/.codex/skills/create-readme/SKILL.md
+++ b/.codex/skills/create-readme/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: create-readme
+description: 'Create a README.md file for the project'
+---
+
+## Role
+
+You're a senior expert software engineer with extensive experience in open source projects. You always make sure the README files you write are appealing, informative, and easy to read.
+
+## Task
+
+1. Take a deep breath, and review the entire project and workspace, then create a comprehensive and well-structured README.md file for the project.
+2. Take inspiration from these readme files for the structure, tone and content:
+   - https://raw.githubusercontent.com/Azure-Samples/serverless-chat-langchainjs/refs/heads/main/README.md
+   - https://raw.githubusercontent.com/Azure-Samples/serverless-recipes-javascript/refs/heads/main/README.md
+   - https://raw.githubusercontent.com/sinedied/run-on-output/refs/heads/main/README.md
+   - https://raw.githubusercontent.com/sinedied/smoke/refs/heads/main/README.md
+3. Do not overuse emojis, and keep the readme concise and to the point.
+4. Do not include sections like "LICENSE", "CONTRIBUTING", "CHANGELOG", etc. There are dedicated files for those sections.
+5. Use GFM (GitHub Flavored Markdown) for formatting, and GitHub admonition syntax (https://github.com/orgs/community/discussions/16925) where appropriate.
+6. If you find a logo or icon for the project, use it in the readme's header.

--- a/.codex/skills/git-commit/SKILL.md
+++ b/.codex/skills/git-commit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: git-commit
+description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+license: MIT
+allowed-tools: Bash
+---
+
+# Git Commit with Conventional Commits
+
+## Overview
+
+Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
+
+## Conventional Commit Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types
+
+| Type       | Purpose                        |
+| ---------- | ------------------------------ |
+| `feat`     | New feature                    |
+| `fix`      | Bug fix                        |
+| `docs`     | Documentation only             |
+| `style`    | Formatting/style (no logic)    |
+| `refactor` | Code refactor (no feature/fix) |
+| `perf`     | Performance improvement        |
+| `test`     | Add/update tests               |
+| `build`    | Build system/dependencies      |
+| `ci`       | CI/config changes              |
+| `chore`    | Maintenance/misc               |
+| `revert`   | Revert commit                  |
+
+## Breaking Changes
+
+```
+# Exclamation mark after type/scope
+feat!: remove deprecated endpoint
+
+# BREAKING CHANGE footer
+feat: allow config to extend other configs
+
+BREAKING CHANGE: `extends` key behavior changed
+```
+
+## Workflow
+
+### 1. Analyze Diff
+
+```bash
+# If files are staged, use staged diff
+git diff --staged
+
+# If nothing staged, use working tree diff
+git diff
+
+# Also check status
+git status --porcelain
+```
+
+### 2. Stage Files (if needed)
+
+If nothing is staged or you want to group changes differently:
+
+```bash
+# Stage specific files
+git add path/to/file1 path/to/file2
+
+# Stage by pattern
+git add *.test.*
+git add src/components/*
+
+# Interactive staging
+git add -p
+```
+
+**Never commit secrets** (.env, credentials.json, private keys).
+
+### 3. Generate Commit Message
+
+Analyze the diff to determine:
+
+- **Type**: What kind of change is this?
+- **Scope**: What area/module is affected?
+- **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
+
+### 4. Execute Commit
+
+```bash
+# Single line
+git commit -m "<type>[scope]: <description>"
+
+# Multi-line with body/footer
+git commit -m "$(cat <<'EOF'
+<type>[scope]: <description>
+
+<optional body>
+
+<optional footer>
+EOF
+)"
+```
+
+## Best Practices
+
+- One logical change per commit
+- Present tense: "add" not "added"
+- Imperative mood: "fix bug" not "fixes bug"
+- Reference issues: `Closes #123`, `Refs #456`
+- Keep description under 72 characters
+
+## Git Safety Protocol
+
+- NEVER update git config
+- NEVER run destructive commands (--force, hard reset) without explicit request
+- NEVER skip hooks (--no-verify) unless user asks
+- NEVER force push to main/master
+- If commit fails due to hooks, fix and create NEW commit (don't amend)

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import vue from "@vitejs/plugin-vue";
-import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import { defineConfig } from "electron-vite";
+import { dependencies } from './package.json'
 
 const workspaceRoot = resolve(__dirname, "../..");
 const appRoot = resolve(__dirname);
@@ -14,11 +15,10 @@ const aliases = {
 export default defineConfig({
   main: {
     envDir: workspaceRoot,
-    plugins: [externalizeDepsPlugin()],
     resolve: { alias: aliases },
     build: {
       rollupOptions: {
-        external: ["electron"],
+        external: ["electron", ...Object.keys(dependencies)],
         input: {
           index: resolve(appRoot, "src/main/index.ts"),
           "utilities/core-entry": resolve(appRoot, "src/utilities/core-entry.ts"),
@@ -29,11 +29,10 @@ export default defineConfig({
     }
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
     resolve: { alias: aliases },
     build: {
       rollupOptions: {
-        external: ["electron"],
+        external: ["electron", ...Object.keys(dependencies)],
         input: { index: resolve(appRoot, "src/preload/index.ts") },
         output: { format: "cjs", entryFileNames: "[name].js" }
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,24 +14,23 @@
     "presmoke": "node ../../tools/ensure-electron-runtime.mjs",
     "smoke": "node scripts/electron-smoke.mjs"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "@deepwrite/contracts": "workspace:*",
     "@deepwrite/pi-runtime-adapter": "workspace:*",
     "@deepwrite/shared": "workspace:*",
-    "electron-updater": "6.6.2",
-    "naive-ui": "2.44.1",
-    "pdfjs-dist": "6.1.200",
-    "pinia": "3.0.4",
-    "vue": "3.5.39"
-  },
-  "devDependencies": {
-    "@types/node": "26.0.1",
-    "@vitejs/plugin-vue": "6.0.7",
-    "electron": "42.5.0",
-    "electron-builder": "26.15.3",
-    "electron-vite": "5.0.0",
-    "typescript": "6.0.3",
-    "vite": "8.1.0",
-    "vue-tsc": "3.3.5"
+    "@types/node": "catalog:",
+    "@vitejs/plugin-vue": "catalog:",
+    "electron": "catalog:",
+    "electron-builder": "catalog:",
+    "electron-updater": "catalog:",
+    "electron-vite": "catalog:",
+    "naive-ui": "catalog:",
+    "pdfjs-dist": "catalog:",
+    "pinia": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
     "pack:test:mac": "node tools/run-test-package.mjs mac all"
   },
   "devDependencies": {
-    "@types/node": "26.0.1",
-    "@vitejs/plugin-vue": "6.0.7",
-    "@vue/tsconfig": "0.9.1",
-    "electron": "42.5.0",
-    "electron-vite": "5.0.0",
-    "typescript": "6.0.3",
-    "vite": "8.1.0",
-    "vitest": "4.1.9",
-    "vue-tsc": "3.3.5"
+    "@types/node": "catalog:",
+    "@vitejs/plugin-vue": "catalog:",
+    "@vue/tsconfig": "catalog:",
+    "electron": "catalog:",
+    "electron-vite": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,6 +7,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "zod": "4.4.3"
+    "zod": "catalog:"
   }
 }

--- a/packages/pi-runtime-adapter/package.json
+++ b/packages/pi-runtime-adapter/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@deepwrite/contracts": "workspace:*",
-    "@earendil-works/pi-agent-core": "0.84.1",
-    "@earendil-works/pi-ai": "0.84.1",
-    "typebox": "1.3.7"
+    "@earendil-works/pi-agent-core": "catalog:",
+    "@earendil-works/pi-ai": "catalog:",
+    "typebox": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,40 +4,100 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@earendil-works/pi-agent-core':
+      specifier: 0.84.1
+      version: 0.84.1
+    '@earendil-works/pi-ai':
+      specifier: 0.84.1
+      version: 0.84.1
+    '@types/node':
+      specifier: 26.0.1
+      version: 26.0.1
+    '@vitejs/plugin-vue':
+      specifier: 6.0.7
+      version: 6.0.7
+    '@vue/tsconfig':
+      specifier: 0.9.1
+      version: 0.9.1
+    electron:
+      specifier: 42.5.0
+      version: 42.5.0
+    electron-builder:
+      specifier: 26.15.3
+      version: 26.15.3
+    electron-updater:
+      specifier: 6.6.2
+      version: 6.6.2
+    electron-vite:
+      specifier: 5.0.0
+      version: 5.0.0
+    naive-ui:
+      specifier: 2.44.1
+      version: 2.44.1
+    pdfjs-dist:
+      specifier: 6.1.200
+      version: 6.1.200
+    pinia:
+      specifier: 3.0.4
+      version: 3.0.4
+    typebox:
+      specifier: 1.3.7
+      version: 1.3.7
+    typescript:
+      specifier: 6.0.3
+      version: 6.0.3
+    vite:
+      specifier: 8.1.0
+      version: 8.1.0
+    vitest:
+      specifier: 4.1.9
+      version: 4.1.9
+    vue:
+      specifier: 3.5.39
+      version: 3.5.39
+    vue-tsc:
+      specifier: 3.3.5
+      version: 3.3.5
+    zod:
+      specifier: 4.4.3
+      version: 4.4.3
+
 importers:
 
   .:
     devDependencies:
       '@types/node':
-        specifier: 26.0.1
+        specifier: 'catalog:'
         version: 26.0.1
       '@vitejs/plugin-vue':
-        specifier: 6.0.7
+        specifier: 'catalog:'
         version: 6.0.7(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
       '@vue/tsconfig':
-        specifier: 0.9.1
+        specifier: 'catalog:'
         version: 0.9.1(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
       electron:
-        specifier: 42.5.0
+        specifier: 'catalog:'
         version: 42.5.0
       electron-vite:
-        specifier: 5.0.0
+        specifier: 'catalog:'
         version: 5.0.0(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
-        specifier: 6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
       vite:
-        specifier: 8.1.0
+        specifier: 'catalog:'
         version: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
-        specifier: 4.1.9
+        specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       vue-tsc:
-        specifier: 3.3.5
+        specifier: 'catalog:'
         version: 3.3.5(typescript@6.0.3)
 
   apps/desktop:
-    dependencies:
+    devDependencies:
       '@deepwrite/contracts':
         specifier: workspace:*
         version: link:../../packages/contracts
@@ -47,51 +107,50 @@ importers:
       '@deepwrite/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      electron-updater:
-        specifier: 6.6.2
-        version: 6.6.2
-      naive-ui:
-        specifier: 2.44.1
-        version: 2.44.1(vue@3.5.39(typescript@6.0.3))
-      pdfjs-dist:
-        specifier: 6.1.200
-        version: 6.1.200
-      pinia:
-        specifier: 3.0.4
-        version: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
-      vue:
-        specifier: 3.5.39
-        version: 3.5.39(typescript@6.0.3)
-    devDependencies:
       '@types/node':
-        specifier: 26.0.1
+        specifier: 'catalog:'
         version: 26.0.1
       '@vitejs/plugin-vue':
-        specifier: 6.0.7
+        specifier: 'catalog:'
         version: 6.0.7(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.39(typescript@6.0.3))
       electron:
-        specifier: 42.5.0
+        specifier: 'catalog:'
         version: 42.5.0
       electron-builder:
-        specifier: 26.15.3
+        specifier: 'catalog:'
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      electron-updater:
+        specifier: 'catalog:'
+        version: 6.6.2
       electron-vite:
-        specifier: 5.0.0
+        specifier: 'catalog:'
         version: 5.0.0(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.44.1(vue@3.5.39(typescript@6.0.3))
+      pdfjs-dist:
+        specifier: 'catalog:'
+        version: 6.1.200
+      pinia:
+        specifier: 'catalog:'
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.39(typescript@6.0.3))
       typescript:
-        specifier: 6.0.3
+        specifier: 'catalog:'
         version: 6.0.3
       vite:
-        specifier: 8.1.0
+        specifier: 'catalog:'
         version: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.39(typescript@6.0.3)
       vue-tsc:
-        specifier: 3.3.5
+        specifier: 'catalog:'
         version: 3.3.5(typescript@6.0.3)
 
   packages/contracts:
     dependencies:
       zod:
-        specifier: 4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
 
   packages/pi-runtime-adapter:
@@ -100,13 +159,13 @@ importers:
         specifier: workspace:*
         version: link:../contracts
       '@earendil-works/pi-agent-core':
-        specifier: 0.84.1
+        specifier: 'catalog:'
         version: 0.84.1(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: 0.84.1
+        specifier: 'catalog:'
         version: 0.84.1(ws@8.21.1)(zod@4.4.3)
       typebox:
-        specifier: 1.3.7
+        specifier: 'catalog:'
         version: 1.3.7
 
   packages/shared: {}
@@ -1030,10 +1089,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,11 +2,32 @@ packages:
   - apps/*
   - packages/*
 
+catalog:
+  "@earendil-works/pi-agent-core": "0.84.1"
+  "@earendil-works/pi-ai": "0.84.1"
+  "@types/node": "26.0.1"
+  "@vitejs/plugin-vue": "6.0.7"
+  "@vue/tsconfig": "0.9.1"
+  electron: "42.5.0"
+  electron-builder: "26.15.3"
+  electron-updater: "6.6.2"
+  electron-vite: "5.0.0"
+  naive-ui: "2.44.1"
+  pdfjs-dist: "6.1.200"
+  pinia: "3.0.4"
+  typebox: "1.3.7"
+  typescript: "6.0.3"
+  vite: "8.1.0"
+  vitest: "4.1.9"
+  vue: "3.5.39"
+  vue-tsc: "3.3.5"
+  zod: "4.4.3"
+
 allowBuilds:
   electron: true
   esbuild: true
   electron-winstaller: false
   # Slice 2 only uses Pi's local Faux provider; these transitive provider
   # packages do not need install scripts for the desktop runtime.
-  '@google/genai': false
+  "@google/genai": false
   protobufjs: false


### PR DESCRIPTION
- **`externalizeDepsPlugin()` 已被 electron-vite 标记为废弃**：`electron.vite.config.ts` 不再使用该 plugin，改为显式声明 `external: ["electron", ...Object.keys(dependencies)]`，行为等价（main / preload 产物不再打包依赖，运行时从 node_modules 加载），且不依赖废弃 API
- electron 在打包时，需要排除的只有含有二进制的包，已修复相关问题
- 版本升级只改 `catalog` 一处即可全仓生效，避免多包版本漂移